### PR TITLE
Allow unhandled chat cmd to be handled by the upstream server

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -65,7 +65,7 @@ func onChatMsg(cc *ClientConn, cmd *mt.ToSrvChatMsg) (string, bool) {
 
 		if !ChatCmdExists(cmdName) {
 			cc.Log("<-", "unknown command", cmdName)
-			return "Command not found.", true
+			return "", false
 		}
 
 		chatCmdsMu.RLock()


### PR DESCRIPTION
When the chat command is not recognized by the proxy, it must be relayed to the game server, since a handler for it might be implemented there.

I return an empty message to avoid sending the (possible) command as a chat message to the client, due to the way it's handled in DoChatMsg (lines 20-27).